### PR TITLE
Add custom domains to TiTiler cloudfront distribution

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,6 +15,7 @@ pytest = "==6.2.5"
 "aws-cdk.assertions" = "==1.126.0"
 "aws-cdk.aws-cloudfront" = "~=1.126.0"
 "aws-cdk.aws-cloudfront-origins" = "~=1.126.0"
+"aws-cdk.aws-certificatemanager" = "~=1.126.0"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "faf07d2d05b3274aa9cc4ea841ccd7d5a97cbbbb3b8df48de9434caba0dfe621"
+            "sha256": "18a04bd8c3110d4652584017cc21143e004ba99cdae65e217b5d07b45e45bb7c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -77,7 +77,7 @@
                 "sha256:29700dd83e4052179c3456e49944e93fd4deae5b5b161056e175fd125312ebdc",
                 "sha256:d382addc6847b98e1daabb7bad1f58e83deb7574038ac4edef73dde3bbf09256"
             ],
-            "markers": "python_version >= '3.6'",
+            "index": "pypi",
             "version": "==1.126.0"
         },
         "aws-cdk.aws-cloudformation": {

--- a/app.py
+++ b/app.py
@@ -1,16 +1,8 @@
 #!/usr/bin/env python3
 import os
 
-from aws_cdk import core as cdk
-
-# For consistency with TypeScript code, `cdk` is the preferred import name for
-# the CDK's core module.  The following line also imports it as `core` for use
-# with examples from the CDK Developer's Guide, which are in the process of
-# being updated to use `cdk`.  You may delete this import if you don't need it.
 from aws_cdk import core
-
 from titiler_service.titiler_service_stack import TitilerServiceStack
-
 
 app = core.App()
 


### PR DESCRIPTION
Closes #15 

Deployed to AWS and OIT added relevant DNS records.

https://map-tiles.princeton.edu/
https://map-tiles-staging.princeton.edu/