### PR TITLE
Update the Titiler base url

### DIFF
--- a/titiler_service/titiler_service_stack.py
+++ b/titiler_service/titiler_service_stack.py
@@ -125,7 +125,7 @@ class TitilerServiceStack(core.Stack):
 
         # Add base url env var so TiTiler generates correct tile URLs.
         # Used in HostMiddleware.
-        lambda_function.add_environment("TITILER_BASE_URL", distribution.domain_name)
+        lambda_function.add_environment("TITILER_BASE_URL", custom_domain)
 
         core.CfnOutput(self, "API Endpoint", value=api.url)
         core.CfnOutput(self, "Cloudfront Endpoint", value=distribution.domain_name)


### PR DESCRIPTION
Closes #24 

Tested in staging and it works as expected.
https://map-tiles-staging.princeton.edu/mosaicjson/WMTSCapabilities.xml?id=f75a1e91ade3427a82a109d321d47cbf :

```
...
<ResourceURL format="image/png" resourceType="tile" template="https://map-tiles-staging.princeton.edu/mosaicjson/tiles/WebMercatorQuad/{TileMatrix}/{TileCol}/{TileRow}@1x.png?id=f75a1e91ade3427a82a109d321d47cbf&url=s3%3A%2F%2Ffiggy-geo-staging%2Ff7%2F5a%2F1e%2Ff75a1e91ade3427a82a109d321d47cbf%2Fmosaic.json"/>
...
```