### PR TITLE
Set minimum TTL

### DIFF
--- a/titiler_service/titiler_service_stack.py
+++ b/titiler_service/titiler_service_stack.py
@@ -109,6 +109,7 @@ class TitilerServiceStack(core.Stack):
             comment="Cache policy for TiTiler",
             default_ttl=core.Duration.days(365),
             max_ttl=core.Duration.days(365),
+            min_ttl=core.Duration.days(365),
             query_string_behavior=aws_cloudfront.CacheQueryStringBehavior.all(),
             enable_accept_encoding_gzip=True,
             enable_accept_encoding_brotli=True


### PR DESCRIPTION
Closes #44

I can confirm with this `age` will go past the `max-age: 3600` and cloudfront will hit.